### PR TITLE
Extract mbg connections info 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ all-in-one-mbg-gui: MAKE_TYPE=MBG
 all-in-one-mbg-gui: clusters-and-workload deploy-mbg deploy-observability ## Deploy everything with mbg with revised GUI
 	@echo -e "\n==> Done (Deploy everything with mbg)\n" 
 
+.PHONY: all-in-one-mbg-gui2
+all-in-one-mbg-gui2: MAKE_TYPE=MBG2 FLP_DOCKER_IMG=quay.io/kalmanmeth/flowlogs-pipeline FLP_DOCKER_TAG=mbg
+all-in-one-mbg-gui2: clusters-and-workload deploy-mbg deploy-observability ## Deploy everything with mbg with revised GUI
+	@echo -e "\n==> Done (Deploy everything with mbg)\n" 
+
 .PHONY: all-in-one-submariner
 all-in-one-submariner: clusters-and-workload deploy-submariner deploy-observability ## Deploy everything with submariner (clusters, cni, loadbalancers, demo-workload, skupper, observability)
 	@echo -e "\n==> Done (Deploy everything with submariner)\n" 

--- a/contrib/mbg/mbg.yaml
+++ b/contrib/mbg/mbg.yaml
@@ -14,14 +14,30 @@ spec:
       labels:
         app: mbg
     spec:
+      volumes:
+      - name: mbg-log-dir
+        emptyDir: {}
       containers:
       - name: mbg
-        image: quay.io/mcnet/mbg
+        image: quay.io/mcnet/mbg:observ
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args: [ "infinity" ]        
         ports:
         - containerPort: 50051
+        volumeMounts:
+        - name: mbg-log-dir
+          mountPath: /root/.mbg/
+      - name: mbg-log
+        image: quay.io/kalmanmeth/mbg-log:test
+        imagePullPolicy: Always
+        command: ["/dump-log"]
+        args: ["/tmp/mbg/mbg.log", "0.0.0.0:9091"]
+        ports:
+        - containerPort: 9091
+        volumeMounts:
+        - name: mbg-log-dir
+          mountPath: /tmp/mbg
 
 ---
 
@@ -43,7 +59,7 @@ spec:
     spec:
       containers:
       - name: mbgctl
-        image: quay.io/mcnet/mbg
+        image: quay.io/mcnet/mbg:observ
         imagePullPolicy: IfNotPresent
         command: [ "sleep" ]
         args: [ "infinity" ]  

--- a/contrib/observability/conf/flp.conf.mbg.yaml
+++ b/contrib/observability/conf/flp.conf.mbg.yaml
@@ -125,9 +125,13 @@ parameters:
         ifDirectionField: IfDirection
 - name: transform_mbg
   transform:
-    type: mbg
-    mbg:
+    type: gateway
+    gateway:
       serverAddr: %MBG_LOG_IP%:%MBG_LOG_PORT%
+      addr1: SrcAddr
+      port1: SrcPort
+      addr2: DstAddr
+      port2: DstPort
 - name: loki
   write:
     type: loki

--- a/contrib/observability/conf/flp.conf.mbg.yaml
+++ b/contrib/observability/conf/flp.conf.mbg.yaml
@@ -1,4 +1,4 @@
-log-level: debug
+log-level: info
 metricsSettings:
   port: 9102
   prefix: flp_op_
@@ -12,7 +12,7 @@ pipeline:
 - name: loki
   follows: transform_mbg
 - name: prometheus
-  follows: enrich
+  follows: transform_mbg
 health:
   port: 8080
 parameters:
@@ -127,7 +127,7 @@ parameters:
   transform:
     type: mbg
     mbg:
-      serverAddr: 10.240.134.210:9091
+      serverAddr: %MBG_LOG_IP%:%MBG_LOG_PORT%
 - name: loki
   write:
     type: loki
@@ -194,4 +194,3 @@ parameters:
         - DstK8S_OwnerType
         buckets:
       prefix: netobserv_
-      expiryTime: 0s

--- a/contrib/observability/conf/flp.conf.skupper.yaml
+++ b/contrib/observability/conf/flp.conf.skupper.yaml
@@ -7,10 +7,8 @@ pipeline:
 - name: ingest
 - name: enrich
   follows: ingest
-- name: transform_mbg
-  follows: enrich
 - name: loki
-  follows: transform_mbg
+  follows: enrich
 - name: prometheus
   follows: enrich
 health:
@@ -123,11 +121,6 @@ parameters:
         dstHostField: DstK8S_HostIP
         flowDirectionField: FlowDirection
         ifDirectionField: IfDirection
-- name: transform_mbg
-  transform:
-    type: mbg
-    mbg:
-      serverAddr: 10.240.134.210:9091
 - name: loki
   write:
     type: loki

--- a/contrib/observability/deployment-flp.yaml
+++ b/contrib/observability/deployment-flp.yaml
@@ -25,7 +25,7 @@ spec:
             - containerPort: 2056
           # When deployed on KinD, the image is pre-pushed to KinD from the local registry.
           # When deployed on OCP, OCP will pull the image from quay.io.
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           volumeMounts:
             - name: configuration
               mountPath: "/etc/flowlogs-pipeline/"

--- a/mk/observability.mk
+++ b/mk/observability.mk
@@ -35,19 +35,19 @@ go-west:
 set-permissions:
 	@echo -e "\n==> Setting permissions\n" 
 	kubectl config use-context kind-east
-	kubectl create clusterrolebinding east-admin --clusterrole=cluster-admin --serviceaccount=netobserv:default --dry-run=client -o yaml | kubectl apply -f - 2>&1
+	kubectl create clusterrolebinding east-admin --clusterrole=cluster-admin --serviceaccount=netobserv-east:default --dry-run=client -o yaml | kubectl apply -f - 2>&1
 	kubectl config use-context kind-west
-	kubectl create clusterrolebinding west-admin --clusterrole=cluster-admin --serviceaccount=netobserv:default --dry-run=client -o yaml | kubectl apply -f - 2>&1
+	kubectl create clusterrolebinding west-admin --clusterrole=cluster-admin --serviceaccount=netobserv-west:default --dry-run=client -o yaml | kubectl apply -f - 2>&1
 
 .PHONY: push-observability-namespaces
 push-observability-namespaces:
 	@echo -e "\n==> Creating and setting observability namespaces\n" 
 	kubectl config use-context kind-east
-	-kubectl create namespace netobserv
-	kubectl config set-context --current --namespace=netobserv
+	-kubectl create namespace netobserv-east
+	kubectl config set-context --current --namespace=netobserv-east
 	kubectl config use-context kind-west
-	-kubectl create namespace netobserv
-	kubectl config set-context --current --namespace=netobserv
+	-kubectl create namespace netobserv-west
+	kubectl config set-context --current --namespace=netobserv-west
 
 .PHONY: pop-namespaces
 pop-namespaces:


### PR DESCRIPTION
This PR enhances the mbg POC by extracting log entries in mbg to obtain the mapping of connection 5-tuples to a global `connectionID` which is valid across clusters. This allows us to identify portions a single flow between different clusters, even though the SrcAddr/DstAddr of the entities is different in the 2 clusters.